### PR TITLE
Add Monoid w constraint to Trans.AccumT instance

### DIFF
--- a/UnexceptionalIO/Trans.hs
+++ b/UnexceptionalIO/Trans.hs
@@ -80,7 +80,7 @@ runExceptIO :: (Exception e, MonadIO m) => Trans.ExceptT e UIO.UIO a -> m a
 runExceptIO = liftIO . UIO.runEitherIO . Trans.runExceptT
 
 #if MIN_VERSION_transformers(0,5,3)
-instance (UIO.Unexceptional m) => UIO.Unexceptional (Trans.AccumT w m) where
+instance (UIO.Unexceptional m, Monoid w) => UIO.Unexceptional (Trans.AccumT w m) where
 	lift = Trans.lift . UIO.lift
 #endif
 


### PR DESCRIPTION
Without this change I get

```
UnexceptionalIO/Trans.hs:84:16: error:
    • Could not deduce (Monoid w) arising from a use of ‘Trans.lift’
      from the context: UIO.Unexceptional m
        bound by the instance declaration
        at UnexceptionalIO/Trans.hs:83:10-70
```